### PR TITLE
fixed SceIoDevInfo conflict with lastest vitasdk.

### DIFF
--- a/psp2shell_m/include/file.h
+++ b/psp2shell_m/include/file.h
@@ -37,12 +37,14 @@
 #define HOME_PATH "root"
 #define DIR_UP ".."
 
+#ifndef _PSP2_IO_DEVCTL_H_
 typedef struct {
     uint64_t max_size;
     uint64_t free_size;
     uint32_t cluster_size;
     void *unk;
 } SceIoDevInfo;
+#endif
 
 enum FileTypes {
     FILE_TYPE_UNKNOWN,


### PR DESCRIPTION
Hello!

Using lastest vitasdk I get this error:

`In file included from psp2shell_m/source/cmd.c:24:0:
psp2shell_m/include/file.h:45:3: error: conflicting types for 'SceIoDevInfo'
 } SceIoDevInfo;
   ^~~~~~~~~~~~
In file included from /opt/toolchains/vitasdk/arm-vita-eabi/include/vitasdk.h:52:0,
                 from psp2shell_m/source/cmd.c:19:
/opt/toolchains/vitasdk/arm-vita-eabi/include/psp2/io/devctl.h:21:3: note: previous declaration of 'SceIoDevInfo' was here
 } SceIoDevInfo;`

This PR resolves checking if _PSP2_IO_DEVCTL_H_ from psp2/io/devctl.h is DEFINED :+1: 

Thanks!